### PR TITLE
Add 2d and 3d examples for parabolic sources

### DIFF
--- a/examples/tree_2d_dgsem/elixir_advection_diffusion_gradient_source_terms.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_diffusion_gradient_source_terms.jl
@@ -1,0 +1,92 @@
+using OrdinaryDiffEqLowStorageRK
+using Trixi
+
+###############################################################################
+# semidiscretization of the linear advection diffusion equation
+
+const a = (0.1, 0.1)
+const nu = 0.1
+const beta = 0.3
+
+equations = LinearScalarAdvectionEquation2D(a)
+equations_parabolic = LaplaceDiffusion2D(nu, equations)
+
+solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
+
+coordinates_min = (-Float64(pi), -Float64(pi))
+coordinates_max = (Float64(pi), Float64(pi))
+
+# Create a uniformly refined mesh with periodic boundaries
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 4,
+                n_cells_max = 30_000,
+                periodicity = true)
+
+initial_condition = function(x, t, equations::LinearScalarAdvectionEquation2D)
+    return SVector(sin(x[1]) * sin(x[2]))
+end
+
+source_terms = function(u, x, t, equations::LinearScalarAdvectionEquation2D)
+    a1, a2 = a
+    sinx, cosx = sincos(x[1])
+    siny, cosy = sincos(x[2])
+    
+    f = a1 * cosx * siny + a2 * sinx * cosy +
+        2 * nu * sinx * siny -
+        beta * (cosx^2 * siny^2 + sinx^2 * cosy^2)
+    return SVector(f)
+end
+
+
+source_terms_parabolic = function(u, gradients, x, t, equations)
+    dudx = gradients[1][1]
+    dudy = gradients[2][1]
+    return SVector(beta * (dudx^2 + dudy^2))
+end
+
+# define periodic boundary conditions everywhere
+boundary_conditions = boundary_condition_periodic
+boundary_conditions_parabolic = boundary_condition_periodic
+
+# A semidiscretization collects data structures and functions for the spatial discretization
+semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabolic),
+                                             initial_condition,
+                                             solver;
+                                             solver_parabolic = ViscousFormulationLocalDG(),
+                                             source_terms = source_terms,
+                                             source_terms_parabolic = source_terms_parabolic,
+                                             boundary_conditions = (boundary_conditions,
+                                                                    boundary_conditions_parabolic))
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+# Create ODE problem with time span from 0.0 to 1.0
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan)
+
+# At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
+# and resets the timers
+summary_callback = SummaryCallback()
+
+# The AnalysisCallback allows to analyse the solution in regular intervals and prints the results
+analysis_callback = AnalysisCallback(semi, interval = 100)
+
+# The AliveCallback prints short status information in regular intervals
+alive_callback = AliveCallback(analysis_interval = 100)
+
+cfl_advective = 0.5
+cfl_diffusive = 0.01  
+stepsize_callback = StepsizeCallback(cfl = cfl_advective,
+                                     cfl_diffusive = cfl_diffusive)
+
+# Create a CallbackSet to collect all callbacks such that they can be passed to the ODE solver
+callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback, stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+# OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
+sol = solve(ode, RDPK3SpFSAL35(); adaptive = false, dt = stepsize_callback(ode),
+            ode_default_options()..., callback = callbacks)
+

--- a/examples/tree_2d_dgsem/elixir_advection_diffusion_gradient_source_terms.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_diffusion_gradient_source_terms.jl
@@ -62,7 +62,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabol
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-tspan = (0.0, 1.0)
+tspan = (0.0, 0.1)
 ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup

--- a/examples/tree_3d_dgsem/elixir_advection_diffusion_gradient_source_terms.jl
+++ b/examples/tree_3d_dgsem/elixir_advection_diffusion_gradient_source_terms.jl
@@ -1,0 +1,91 @@
+using OrdinaryDiffEqLowStorageRK
+using Trixi
+
+###############################################################################
+# semidiscretization of the linear advection diffusion equation
+
+const a = (0.1, 0.1, 0.1)
+const nu = 0.1
+const beta = 0.3
+
+equations = LinearScalarAdvectionEquation3D(a)
+equations_parabolic = LaplaceDiffusion3D(nu, equations)
+
+solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
+
+# Create a uniformly refined mesh with periodic boundaries
+mesh = TreeMesh((-Float64(pi), -Float64(pi), -Float64(pi)),
+                (Float64(pi), Float64(pi), Float64(pi));
+                initial_refinement_level = 3,
+                n_cells_max = 30_000,
+                periodicity = true)
+
+initial_condition = function (x, t, equations::LinearScalarAdvectionEquation3D)
+    return SVector(sin(x[1]) * sin(x[2]) * sin(x[3]))
+end
+
+source_terms = function (u, x, t, equations::LinearScalarAdvectionEquation3D)
+    sinx, cosx = sincos(x[1])
+    siny, cosy = sincos(x[2])
+    sinz, cosz = sincos(x[3])
+    
+    f = a[1] * cosx * siny * sinz + a[2] * sinx * cosy * sinz + a[3] * sinx * siny * cosz +
+        3 * nu * sinx * siny * sinz -
+        beta * (cosx^2 * siny^2 * sinz^2 + sinx^2 * cosy^2 * sinz^2 + sinx^2 * siny^2 * cosz^2)
+    return SVector(f)
+end
+
+source_terms_parabolic = function (u, gradients, x, t, equations)
+    dudx = gradients[1][1]
+    dudy = gradients[2][1]
+    dudz = gradients[3][1]
+    return SVector(beta * (dudx^2 + dudy^2 + dudz^2))
+end
+
+# define periodic boundary conditions everywhere
+boundary_conditions = boundary_condition_periodic
+boundary_conditions_parabolic = boundary_condition_periodic
+
+# A semidiscretization collects data structures and functions for the spatial discretization
+semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabolic),
+                                             initial_condition,
+                                             solver;
+                                             solver_parabolic = ViscousFormulationLocalDG(),
+                                             source_terms = source_terms,
+                                             source_terms_parabolic = source_terms_parabolic,
+                                             boundary_conditions = (boundary_conditions,
+                                                                    boundary_conditions_parabolic))
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+# Create ODE problem with time span from 0.0 to 1.0
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan)
+
+# At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
+# and resets the timers
+summary_callback = SummaryCallback()
+
+# The AnalysisCallback allows to analyse the solution in regular intervals and prints the results
+analysis_callback = AnalysisCallback(semi, interval = 100)
+
+# The AliveCallback prints short status information in regular intervals
+alive_callback = AliveCallback(analysis_interval = 100)
+
+cfl_advective = 0.5   # Not restrictive for this example
+cfl_diffusive = 0.01  # Restricts the timestep
+stepsize_callback = StepsizeCallback(cfl = cfl_advective,
+                                     cfl_diffusive = cfl_diffusive)
+
+# Create a CallbackSet to collect all callbacks such that they can be passed to the ODE solver
+callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback,
+                        stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+# OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
+sol = solve(ode, RDPK3SpFSAL35(); adaptive = false, dt = stepsize_callback(ode),
+            ode_default_options()..., callback = callbacks)
+

--- a/examples/tree_3d_dgsem/elixir_advection_diffusion_gradient_source_terms.jl
+++ b/examples/tree_3d_dgsem/elixir_advection_diffusion_gradient_source_terms.jl
@@ -60,7 +60,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabol
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-tspan = (0.0, 1.0)
+tspan = (0.0, 0.1)
 ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup

--- a/src/solvers/dgsem_tree/dg_2d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_2d_parabolic.jl
@@ -1052,17 +1052,18 @@ function calc_sources_parabolic!(du, u, gradients, t, source_terms,
                                  equations_parabolic::AbstractEquations{2}, dg::DG,
                                  cache)
     @unpack node_coordinates = cache.elements
+    equations = equations_parabolic.equations_hyperbolic
 
     @threaded for element in eachelement(dg, cache)
         for j in eachnode(dg), i in eachnode(dg)
-            u_local = get_node_vars(u, equations_parabolic, dg, i, j, element)
-            gradients_x_local = get_node_vars(gradients[1], equations_parabolic, dg, i, j, element)
-            gradients_y_local = get_node_vars(gradients[2], equations_parabolic, dg, i, j, element)
+            u_local = get_node_vars(u, equations, dg, i, j, element)
+            gradients_x_local = get_node_vars(gradients[1], equations, dg, i, j, element)
+            gradients_y_local = get_node_vars(gradients[2], equations, dg, i, j, element)
             gradients_local = (gradients_x_local, gradients_y_local)
-            x_local = get_node_coords(node_coordinates, equations_parabolic, dg,
+            x_local = get_node_coords(node_coordinates, equations, dg,
                                       i, j, element)
             du_local = source_terms(u_local, gradients_local, x_local, t, equations_parabolic)
-            add_to_node_vars!(du, du_local, equations_parabolic, dg, i, j, element)
+            add_to_node_vars!(du, du_local, equations, dg, i, j, element)
         end
     end
 

--- a/src/solvers/dgsem_tree/dg_2d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_2d_parabolic.jl
@@ -1052,21 +1052,17 @@ function calc_sources_parabolic!(du, u, gradients, t, source_terms,
                                  equations_parabolic::AbstractEquations{2}, dg::DG,
                                  cache)
     @unpack node_coordinates = cache.elements
-    @unpack equations = equations_parabolic
 
     @threaded for element in eachelement(dg, cache)
         for j in eachnode(dg), i in eachnode(dg)
-            u_local = get_node_vars(u, equations, dg, i, j, element)
-            gradients_x_local = get_node_vars(gradients[1], equations, dg, i, j,
-                                              element)
-            gradients_y_local = get_node_vars(gradients[2], equations, dg, i, j,
-                                              element)
+            u_local = get_node_vars(u, equations_parabolic, dg, i, j, element)
+            gradients_x_local = get_node_vars(gradients[1], equations_parabolic, dg, i, j, element)
+            gradients_y_local = get_node_vars(gradients[2], equations_parabolic, dg, i, j, element)
             gradients_local = (gradients_x_local, gradients_y_local)
-            x_local = get_node_coords(node_coordinates, equations, dg,
+            x_local = get_node_coords(node_coordinates, equations_parabolic, dg,
                                       i, j, element)
-            du_local = source_terms(u_local, gradients_local, x_local, t,
-                                    equations_parabolic)
-            add_to_node_vars!(du, du_local, equations, dg, i, j, element)
+            du_local = source_terms(u_local, gradients_local, x_local, t, equations_parabolic)
+            add_to_node_vars!(du, du_local, equations_parabolic, dg, i, j, element)
         end
     end
 

--- a/src/solvers/dgsem_tree/dg_3d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_3d_parabolic.jl
@@ -1155,18 +1155,19 @@ end
 function calc_sources_parabolic!(du, u, gradients, t, source_terms,
                                  equations_parabolic::AbstractEquations{3}, dg::DG, cache)
     @unpack node_coordinates = cache.elements
+    equations = equations_parabolic.equations_hyperbolic
 
     @threaded for element in eachelement(dg, cache)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-            u_local = get_node_vars(u, equations_parabolic, dg, i, j, k, element)
-            gradients_x_local = get_node_vars(gradients[1], equations_parabolic, dg, i, j, k, element)
-            gradients_y_local = get_node_vars(gradients[2], equations_parabolic, dg, i, j, k, element)
-            gradients_z_local = get_node_vars(gradients[3], equations_parabolic, dg, i, j, k, element)
+            u_local = get_node_vars(u, equations, dg, i, j, k, element)
+            gradients_x_local = get_node_vars(gradients[1], equations, dg, i, j, k, element)
+            gradients_y_local = get_node_vars(gradients[2], equations, dg, i, j, k, element)
+            gradients_z_local = get_node_vars(gradients[3], equations, dg, i, j, k, element)
             gradients_local = (gradients_x_local, gradients_y_local, gradients_z_local)
-            x_local = get_node_coords(node_coordinates, equations_parabolic, dg,
+            x_local = get_node_coords(node_coordinates, equations, dg,
                                       i, j, k, element)
             du_local = source_terms(u_local, gradients_local, x_local, t, equations_parabolic)
-            add_to_node_vars!(du, du_local, equations_parabolic, dg, i, j, k, element)
+            add_to_node_vars!(du, du_local, equations, dg, i, j, k, element)
         end
     end
 


### PR DESCRIPTION
@jlchan Implemented 2d and 3d analogue of the advection-diffusion elixir with a parabolic source and a manufactured source based on a defined solution. 

Changed unpacking of `equations_parabolic` in `calc_sources_parabolic!` to unpack `LaplaceDiffusion2D/3D` correctly